### PR TITLE
helloWorld.js statusCode as a sibling of body

### DIFF
--- a/src/app.functions/helloWorld.js
+++ b/src/app.functions/helloWorld.js
@@ -7,7 +7,7 @@ exports.main = ({ params }, sendResponse) => {
     body: {
       greeting: `Hello, ${name || "World"}!`,
       humanReadableTime,
-      statusCode: 200,
     },
+    statusCode: 200,
   });
 };


### PR DESCRIPTION
When I installed / invoked the boilerplate via `hs create webpack-serverless` I found that the `statusCode` was returned as part of the response `body` and did not control the status code of the http response. Prior to this change, the browser and curl would always have a 200 response, regardless of what `statusCode` is set to. 

I checked other invocations of `sendResponse` and they looked correct. https://github.com/HubSpot/cms-webpack-serverless-boilerplate/blob/904f8d6a4e5e5baa339f31c78969ffef844b3118/src/app.functions/fetchLP.js#L29